### PR TITLE
Allow for yarn workspaces

### DIFF
--- a/src/Ignitor/index.js
+++ b/src/Ignitor/index.js
@@ -428,7 +428,7 @@ class Ignitor {
     this._callHooks('before', 'registerCommands')
 
     const { commands } = this._getAppAttributes()
-    const ace = require(path.join(this._appRoot, '/node_modules/@adonisjs/ace'))
+    const ace = require('@adonisjs/ace')
     commands.forEach((command) => ace.addCommand(command))
 
     this._callHooks('after', 'registerCommands')
@@ -694,7 +694,7 @@ class Ignitor {
     this.loadCommands()
     await this.fire()
 
-    const ace = require(path.join(this._appRoot, '/node_modules/@adonisjs/ace'))
+    const ace = require('@adonisjs/ace')
     ace.wireUpWithCommander()
     const version = this._packageFile['adonis-version'] || 'NA'
 


### PR DESCRIPTION
Adonis makes the assumption that node_modules will always be in the app root. With yarn workspaces or monorepo setups, it's not in the app root, but in the project root instead. This PR makes it possible to use adonis in such environments.