### PR TITLE
feat(Ignitor): allow to set modulesRoot

### DIFF
--- a/src/Ignitor/index.js
+++ b/src/Ignitor/index.js
@@ -47,6 +47,7 @@ class Ignitor {
   constructor (fold) {
     this._fold = fold
     this._appRoot = null
+    this._modulesRoot = null
     this._loadCommands = false
 
     /**
@@ -408,7 +409,8 @@ class Ignitor {
     this._callHooks('before', 'registerCommands')
 
     const { commands } = this._getAppAttributes()
-    const ace = require(path.join(this._appRoot, '/node_modules/@adonisjs/ace'))
+    const root = this._modulesRoot || this._appRoot
+    const ace = require(path.join(root, '/node_modules/@adonisjs/ace'))
     commands.forEach((command) => ace.addCommand(command))
 
     this._callHooks('after', 'registerCommands')
@@ -513,7 +515,8 @@ class Ignitor {
   _invokeAce () {
     this._callHooks('before', 'aceCommand')
 
-    const ace = require(path.join(this._appRoot, '/node_modules/@adonisjs/ace'))
+    const root = this._modulesRoot || this._appRoot
+    const ace = require(path.join(root, '/node_modules/@adonisjs/ace'))
     ace.wireUpWithCommander()
 
     /**
@@ -656,6 +659,22 @@ class Ignitor {
    */
   appRoot (location) {
     this._appRoot = location
+    return this
+  }
+
+  /**
+   * Set application modules root. This path
+   * contains the node_modules directory with
+   * the application's dependencies.
+   *
+   * @method modulesRoot
+   *
+   * @param  {String} location
+   *
+   * @chainable
+   */
+  modulesRoot (location) {
+    this._modulesRoot = location
     return this
   }
 

--- a/test/ignitor.spec.js
+++ b/test/ignitor.spec.js
@@ -39,6 +39,12 @@ test.group('Ignitor', (group) => {
     assert.equal(ignitor._appRoot, 'foo')
   })
 
+  test('register modules root', (assert) => {
+    const ignitor = new Ignitor()
+    ignitor.modulesRoot('foo')
+    assert.equal(ignitor._modulesRoot, 'foo')
+  })
+
   test('default app file to start/app.js', (assert) => {
     const ignitor = new Ignitor()
     assert.equal(ignitor._appFile, 'start/app.js')
@@ -267,6 +273,13 @@ test.group('Ignitor', (group) => {
     } catch ({ message }) {
       assert.equal(message, `Cannot find module 'Adonis/Src/Command'`)
     }
+  })
+
+  test('fire ace when app and modules roots are different', async () => {
+    const ignitor = new Ignitor(fold)
+    ignitor.appRoot(__dirname)
+    ignitor.modulesRoot(path.join(__dirname, '..'))
+    await ignitor.fireAce()
   })
 
   test('setup resolver', async (assert) => {


### PR DESCRIPTION
## Proposed changes

Sometimes, appRoot is not necessarily the directory which contains
node_modules (for example when the AdonisJs app is in a subdirectory
of a bigger application.
`ignitor.modulesRoot(location)` allows to specify a different directory to
look for dependencies such as `@adonisjs/ace`.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-ignitor/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
