### PR TITLE
feat(ignitor): add loadOnlyOnHttp file list

### DIFF
--- a/test/ignitor.spec.js
+++ b/test/ignitor.spec.js
@@ -239,6 +239,16 @@ test.group('Ignitor', (group) => {
     await ignitor.fireHttpServer()
   })
 
+  test('do not load http only files when firing ace', async (assert) => {
+    const ignitor = new Ignitor(fold)
+    ignitor.appRoot(path.join(__dirname, './'))
+    ignitor._preLoadOnHttpOnly = ['start/emitsError']
+    ignitor._startHttpServer = function () {}
+    ignitor._gracefullyShutDown = function () {}
+
+    await ignitor.fireAce()
+  })
+
   test('call preloading hooks', async (assert) => {
     const ignitor = new Ignitor(fold)
     const events = []


### PR DESCRIPTION
Hey! 👋 

This add a way to disable the loading of some files when using Ignitor to fire Ace Command.

In the current implementation, having `socket.js` to be preloaded when running ace could prevent Node to exit the process if your code start any long-living connection.

On this PR, the test works but it seems that it's testing nothing. After some debugging it seems that  some tests are green without really testing something.

Also, the test `load ace providers when fireAce command is called` seems to not work anymore because the `Require Stack` is added to the exception's message.